### PR TITLE
Fix f-string syntax bug in py3.11

### DIFF
--- a/blastai/tools.py
+++ b/blastai/tools.py
@@ -320,7 +320,7 @@ class Tools:
                         output_parts.append("\n")
                     output_parts.extend(text_results)
 
-                msg = f'📄 Extracted from page:\n{"\n".join(output_parts)}\n'
+                msg = "📄 Extracted from page:\n" + "\n".join(output_parts) + "\n"
                 return ActionResult(extracted_content=msg, include_in_memory=True)
                 
             except Exception as e:


### PR DESCRIPTION
Fixes the following bug when running `blastai serve` in Python3.11 environment.

```
Traceback (most recent call last):
  File "/Users/cailinw/Documents/_projects/blast/blast-venv/bin/blastai", line 5, in <module>
    from blastai.cli import main
  File "/Users/cailinw/Documents/_projects/blast/blastai/__init__.py", line 14, in <module>
    from .engine import Engine
  File "/Users/cailinw/Documents/_projects/blast/blastai/engine.py", line 16, in <module>
    from .resource_manager import ResourceManager
  File "/Users/cailinw/Documents/_projects/blast/blastai/resource_manager.py", line 56, in <module>
    from .tools import Tools
  File "/Users/cailinw/Documents/_projects/blast/blastai/tools.py", line 323
    msg = f'📄 Extracted from page:\n{"\n".join(output_parts)}\n'
                                                                ^
SyntaxError: f-string expression part cannot include a backslash
```