### PR TITLE
Fixes for First-of-N Parallelism and Logging

### DIFF
--- a/blastai/logging_setup.py
+++ b/blastai/logging_setup.py
@@ -224,6 +224,9 @@ def setup_logging(settings: Optional[Settings] = None, engine_hash: Optional[str
         logger = logging.getLogger(name)
         logger.setLevel(level)
         
+        # Clear any existing handlers
+        logger.handlers.clear()
+        
         # Add handler specifically for this logger
         handler = logging.FileHandler(engine_log)
         handler.setFormatter(formatter)
@@ -245,6 +248,8 @@ def setup_logging(settings: Optional[Settings] = None, engine_hash: Optional[str
         for child in ['server', 'engine', 'scheduler', 'executor']:
             child_logger = logging.getLogger(f"{name}.{child}")
             child_logger.setLevel(level)
+            # Clear any existing handlers
+            child_logger.handlers.clear()
 
 def should_show_metrics(settings: Settings) -> bool:
     """Always return True since metrics should always be shown."""

--- a/blastai/planner.py
+++ b/blastai/planner.py
@@ -178,7 +178,7 @@ Plan: search for list of top 8 biotech companies --> get list of CEOs from that 
 
             if parallelism.get("first_of_n", False):
                 guidance_parts.append(
-                    f'Execute launch_subtask(task="{task_description}", num_copies=3) '
+                    f'Execute launch_subtask(task="{task_description}", optional_initial_search_or_url={initial_url}, num_copies=3) '
                     "--> then get_first_subtask_result with the returned subtask IDs"
                 )
 

--- a/blastai/planner.py
+++ b/blastai/planner.py
@@ -180,6 +180,7 @@ Plan: search for list of top 8 biotech companies --> get list of CEOs from that 
                 guidance_parts.append(
                     f'Execute launch_subtask(task="{task_description}", optional_initial_search_or_url={initial_url}, num_copies=3) '
                     "--> then get_first_subtask_result with the returned subtask IDs"
+                    " Do not attempt to complete the task yourself - delegate it to subtasks."
                 )
 
             if parallelism.get("task", False):

--- a/blastai/resource_factory.py
+++ b/blastai/resource_factory.py
@@ -119,7 +119,7 @@ async def create_executor(
         browser_args = {
             'headless': constraints.require_headless,
             'user_data_dir': None,  # Use ephemeral profile for security
-            'keep_alive': True,  # Keep browser alive between tasks
+            'keep_alive': False,  # Set to False so agent.close() can clean up
             'highlight_elements': False,  # Disable element highlighting
         }
         

--- a/blastai/resource_factory_utils.py
+++ b/blastai/resource_factory_utils.py
@@ -411,7 +411,7 @@ async def launch_vnc_session(target_url: str, stealth: bool = False) -> VNCSessi
         browser_args = {
             'headless': False,
             'highlight_elements': False,  # Disable element highlighting
-            'keep_alive': True,  # Keep browser alive between tasks
+            'keep_alive': False,  # Set to False so agent.close() can clean up
             'env': env,
             'args': [
                 "--disable-gpu",

--- a/blastai/resource_factory_utils.py
+++ b/blastai/resource_factory_utils.py
@@ -25,7 +25,7 @@ allocated_displays = set()
 def get_stealth_profile_dir(task_id: str) -> str:
     """Get a unique stealth profile directory path for a task."""
     base_stealth_dir = os.path.expanduser('~/.config/browseruse/profiles/stealth')
-    stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}_{int(time.time() * 1000)}')
+    stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}')
     
     base_stealth_path = Path(base_stealth_dir)
     stealth_dir_path = Path(stealth_dir)
@@ -36,10 +36,13 @@ def get_stealth_profile_dir(task_id: str) -> str:
     
     # Create task-specific directory
     if stealth_dir_path.exists():
-        logger.warning(f"Stealth directory already exists: {stealth_dir}")
-        # Add PID for uniqueness
-        stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}_{int(time.time() * 1000)}_{os.getpid()}')
-        stealth_dir_path = Path(stealth_dir)
+        try:
+            shutil.rmtree(stealth_dir)
+        except OSError as e:
+            logger.warning(f"Failed to remove existing stealth directory: {e}")
+            # Try to create a unique directory instead
+            stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}_{int(time.time())}')
+            stealth_dir_path = Path(stealth_dir)
     
     if base_stealth_path.exists():
         try:
@@ -408,7 +411,7 @@ async def launch_vnc_session(target_url: str, stealth: bool = False) -> VNCSessi
         browser_args = {
             'headless': False,
             'highlight_elements': False,  # Disable element highlighting
-            'keep_alive': False,  # Don't keep browser alive between tasks to avoid resource leaks
+            'keep_alive': True,  # Keep browser alive between tasks
             'env': env,
             'args': [
                 "--disable-gpu",

--- a/blastai/resource_factory_utils.py
+++ b/blastai/resource_factory_utils.py
@@ -25,7 +25,7 @@ allocated_displays = set()
 def get_stealth_profile_dir(task_id: str) -> str:
     """Get a unique stealth profile directory path for a task."""
     base_stealth_dir = os.path.expanduser('~/.config/browseruse/profiles/stealth')
-    stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}')
+    stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}_{int(time.time() * 1000)}')
     
     base_stealth_path = Path(base_stealth_dir)
     stealth_dir_path = Path(stealth_dir)
@@ -36,13 +36,10 @@ def get_stealth_profile_dir(task_id: str) -> str:
     
     # Create task-specific directory
     if stealth_dir_path.exists():
-        try:
-            shutil.rmtree(stealth_dir)
-        except OSError as e:
-            logger.warning(f"Failed to remove existing stealth directory: {e}")
-            # Try to create a unique directory instead
-            stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}_{int(time.time())}')
-            stealth_dir_path = Path(stealth_dir)
+        logger.warning(f"Stealth directory already exists: {stealth_dir}")
+        # Add PID for uniqueness
+        stealth_dir = os.path.expanduser(f'~/.config/browseruse/profiles/stealth_{task_id}_{int(time.time() * 1000)}_{os.getpid()}')
+        stealth_dir_path = Path(stealth_dir)
     
     if base_stealth_path.exists():
         try:
@@ -411,7 +408,7 @@ async def launch_vnc_session(target_url: str, stealth: bool = False) -> VNCSessi
         browser_args = {
             'headless': False,
             'highlight_elements': False,  # Disable element highlighting
-            'keep_alive': True,  # Keep browser alive between tasks
+            'keep_alive': False,  # Don't keep browser alive between tasks to avoid resource leaks
             'env': env,
             'args': [
                 "--disable-gpu",

--- a/blastai/tools.py
+++ b/blastai/tools.py
@@ -196,7 +196,7 @@ class Tools:
                     success=False,
                     error="No valid task IDs provided (filtered out current task)"
                 )
-            return await self._get_first_subtask_result(scheduler, task_ids, as_final=False)
+            return await self._get_first_subtask_result(scheduler, task_ids, as_final=True)
 
         @self.controller.action("""Extract structured, semantic data (e.g. product description, price, all information about XYZ) from the current webpage based on a textual query.
 Only use this for extracting info from a single product/article page, not for entire listings or search results pages.

--- a/blastai/tools.py
+++ b/blastai/tools.py
@@ -196,7 +196,7 @@ class Tools:
                     success=False,
                     error="No valid task IDs provided (filtered out current task)"
                 )
-            return await self._get_first_subtask_result(scheduler, task_ids, as_final=True)
+            return await self._get_first_subtask_result(scheduler, task_ids, as_final=False)
 
         @self.controller.action("""Extract structured, semantic data (e.g. product description, price, all information about XYZ) from the current webpage based on a textual query.
 Only use this for extracting info from a single product/article page, not for entire listings or search results pages.

--- a/experiments/runner.py
+++ b/experiments/runner.py
@@ -285,7 +285,7 @@ class ExperimentRunner:
 
 
 async def main():
-    config_path = "experiments/configs/test_first_of_n.yaml"
+    config_path = "experiments/configs/testing-experiment-config.yaml"
     if not os.path.exists(config_path):
         print(f"Config file not found: {config_path}")
         return

--- a/experiments/runner.py
+++ b/experiments/runner.py
@@ -26,6 +26,8 @@ class ExperimentResult:
 
     experiment_id: str
     engine_id: str
+    llm_model: str
+    llm_model_mini: str
     stage_name: str
     run_number: int
     success: bool
@@ -176,6 +178,8 @@ class ExperimentRunner:
             result = ExperimentResult(
                 experiment_id=experiment_id,
                 engine_id=engine._instance_hash,
+                llm_model=engine_config["constraints"]["llm_model"],
+                llm_model_mini=engine_config["constraints"]["llm_model_mini"],
                 stage_name=stage_name,
                 run_number=run_number,
                 success=False,

--- a/experiments/runner.py
+++ b/experiments/runner.py
@@ -130,6 +130,7 @@ class ExperimentRunner:
                 "require_human_in_loop": False,
                 "share_browser_process": False,
                 "allowed_domains": None,
+                "allow_vision": False,
                 **stage_config,  # Override with stage-specific parallelism config
             },
         }
@@ -284,7 +285,7 @@ class ExperimentRunner:
 
 
 async def main():
-    config_path = "experiments/configs/testing-experiment-config.yaml"
+    config_path = "experiments/configs/test_first_of_n.yaml"
     if not os.path.exists(config_path):
         print(f"Config file not found: {config_path}")
         return


### PR DESCRIPTION
`blastai/logging_setup.py`
- Fix issue where existing logging file handlers for an engine are not properly cleared

`blastai/planner.py`
- Small fix to make sure the task `initial_url` is being used
- Instruct the agent to always delegate to subtasks when using first-of-n

`blastai/resource_factory.py` + `blastai/resource_factory_utils.py`
- Currently, the `BrowserSession` resource cleanup relies on [`agent.close()`](https://github.com/stanford-mast/blast/blob/main/blastai/executor.py#L368), which calls `await self.browser_session.stop()`. This stop only works if `keep_alive=False`. 
  - If we want to keep the browser session for any reason, I can change this back! Making this change because I noticed a few dangling browser session PIDs running in the background.

`experiments/runner.py`
- Set `allow_vision=False` to prevent Browser Use from using vision mode
- Record LLM model in experiment results
