### PR TITLE
Read version from package metadata instead of hardcoding

### DIFF
--- a/blastai/cli.py
+++ b/blastai/cli.py
@@ -13,6 +13,7 @@ os.environ["BROWSER_USE_DISABLE_LOGGING"] = "true"
 import asyncio
 import logging
 import sys
+from importlib.metadata import version
 from pathlib import Path
 from typing import Optional
 
@@ -43,7 +44,7 @@ console = Console()
 
 
 @click.group(invoke_without_command=True)
-@click.version_option("0.1.6", "-V", "--version", prog_name="BLAST")
+@click.version_option(version("blastai"), "-V", "--version", prog_name="BLAST")
 @click.pass_context
 def cli(ctx):
     """🚀  Browser-LLM Auto-Scaling Technology"""

--- a/blastai/server.py
+++ b/blastai/server.py
@@ -8,6 +8,7 @@ os.environ["ANONYMIZED_TELEMETRY"] = "false"
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from importlib.metadata import version
 from typing import Dict, Optional
 
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
@@ -91,7 +92,7 @@ async def lifespan(app: FastAPI):
             await handle_shutdown()
 
 
-app = FastAPI(title="BlastAI API", version="0.1.6", lifespan=lifespan)
+app = FastAPI(title="BlastAI API", version=version("blastai"), lifespan=lifespan)
 
 # Configure CORS for development
 app.add_middleware(


### PR DESCRIPTION
Use `importlib.metadata.version` in cli.py and server.py so pyproject.toml is the single source of truth for the version string.