### PR TITLE
feat: support external browsers over CDP

### DIFF
--- a/blastai/config.py
+++ b/blastai/config.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class Settings(BaseModel):
@@ -11,6 +11,11 @@ class Settings(BaseModel):
     local_browser_path: str = Field(
         default="none",
         description="Path to local Chrome/Chromium browser binary. Set to 'auto' to auto-detect, 'none' to use default, or provide specific path",
+    )
+
+    browser_cdp_url: Optional[str] = Field(
+        default=None,
+        description="HTTP(S) or WebSocket CDP URL for an existing local or remote Chromium browser",
     )
 
     persist_cache: bool = Field(default=False, description="Whether to persist cache between runs")
@@ -30,6 +35,25 @@ class Settings(BaseModel):
     server_port: int = Field(default=8000, description="Port number for the BLAST server")
 
     web_port: int = Field(default=3000, description="Port number for the web UI")
+
+    @field_validator("browser_cdp_url")
+    @classmethod
+    def validate_browser_cdp_url(cls, value: Optional[str]) -> Optional[str]:
+        """Only accept URL forms supported by Browser Use's CDP connector."""
+        if value is None:
+            return None
+
+        value = value.strip()
+        if not value.startswith(("http://", "https://", "ws://", "wss://")):
+            raise ValueError("browser_cdp_url must start with http://, https://, ws://, or wss://")
+        return value
+
+    @model_validator(mode="after")
+    def validate_browser_source(self):
+        """A session cannot launch a local executable and connect over CDP."""
+        if self.browser_cdp_url and self.local_browser_path != "none":
+            raise ValueError("browser_cdp_url and local_browser_path cannot be set together")
+        return self
 
     @classmethod
     def create(cls, **kwargs):

--- a/blastai/default_config.yaml
+++ b/blastai/default_config.yaml
@@ -1,5 +1,6 @@
 settings:
   local_browser_path: "none"  # Path to Chrome/Chromium binary: "none" (default), "auto" for auto-detect, or specific path
+  browser_cdp_url: null  # Existing local or remote Chromium: http(s):// or ws(s):// CDP URL
   persist_cache: false
   browser_use_log_level: "debug"  # Logging level for browser-use module
   blastai_log_level: "debug"  # Logging level for blastai module

--- a/blastai/resource_factory.py
+++ b/blastai/resource_factory.py
@@ -22,6 +22,47 @@ from .browser_session_patch import apply_all_patches
 _patches_applied = False
 
 
+def _build_browser_args(task_id: str, constraints: Constraints, settings: Settings) -> Dict[str, Any]:
+    """Build BrowserSession arguments without starting a browser."""
+    browser_args: Dict[str, Any] = {
+        "headless": constraints.require_headless,
+        "user_data_dir": None,
+        "keep_alive": True,
+        "highlight_elements": False,
+    }
+
+    if constraints.allowed_domains is not None:
+        browser_args["allowed_domains"] = constraints.allowed_domains
+
+    if settings.browser_cdp_url:
+        browser_args["cdp_url"] = settings.browser_cdp_url
+    elif settings.local_browser_path != "none":
+        if settings.local_browser_path == "auto":
+            browser_path = find_local_browser()
+            if browser_path:
+                browser_args["executable_path"] = browser_path
+                logger.debug(f"Using auto-detected browser at: {browser_path}")
+        else:
+            browser_path = settings.local_browser_path
+            if not os.path.exists(browser_path):
+                raise FileNotFoundError(f"Specified local browser path does not exist: {browser_path}")
+            browser_args["executable_path"] = browser_path
+
+    if constraints.require_patchright and not settings.browser_cdp_url:
+        logger.info(
+            "Patchright is no longer supported starting in Browser Use v0.6.0rc1. Creating browser session without patchright."
+        )
+        stealth_dir = get_stealth_profile_dir(task_id)
+        browser_args["user_data_dir"] = stealth_dir
+        browser_args["disable_security"] = False
+        browser_args["deterministic_rendering"] = False
+        logger.debug(f"Using patchright for browser automation with profile: {stealth_dir}")
+    elif constraints.require_patchright:
+        logger.info("External CDP browser controls its own browser binary and profile")
+
+    return browser_args
+
+
 async def create_executor(
     task_id: str,
     constraints: Constraints,
@@ -110,44 +151,8 @@ async def create_executor(
             f"Task {task_id}: is_interactive={is_interactive}, has_queues={task.interactive_queues is not None if task else False}"
         )
 
-        # Configure regular browser session
-        browser_args = {
-            "headless": constraints.require_headless,
-            "user_data_dir": None,  # Use ephemeral profile for security
-            "keep_alive": True,
-            "highlight_elements": False,  # Disable element highlighting
-        }
-
-        # Add allowed domains if configured
-        if constraints.allowed_domains is not None:
-            browser_args["allowed_domains"] = constraints.allowed_domains
-
-        # Handle local browser path if not "none"
-        if settings.local_browser_path != "none":
-            if settings.local_browser_path == "auto":
-                browser_path = find_local_browser()
-                if browser_path:
-                    browser_args["executable_path"] = browser_path
-                    logger.debug(f"Using auto-detected browser at: {browser_path}")
-            else:
-                browser_path = settings.local_browser_path
-                if not os.path.exists(browser_path):
-                    logger.error(f"Specified local browser path does not exist: {browser_path}")
-                    return None
-                browser_args["executable_path"] = browser_path
-
-        # Initialize patchright if required
-        if constraints.require_patchright:
-            logger.info(
-                "Patchright is no longer supported starting in Browser Use v0.6.0rc1. Creating browser session without patchright."
-            )
-
-            # Get stealth profile directory path
-            stealth_dir = get_stealth_profile_dir(task_id)
-            browser_args["user_data_dir"] = stealth_dir
-            browser_args["disable_security"] = False
-            browser_args["deterministic_rendering"] = False
-            logger.debug(f"Using patchright for browser automation with profile: {stealth_dir}")
+        # Configure regular browser session.
+        browser_args = _build_browser_args(task_id, constraints, settings)
 
         # Create and start browser session
         browser_session = BrowserSession(**browser_args)
@@ -171,7 +176,8 @@ async def create_executor(
     except Exception as e:
         logger.error(f"Failed to create executor: {e}")
         # Clean up resources on failure (non-VNC path only)
-        if constraints.require_patchright and not constraints.require_human_in_loop:
+        stealth_dir = browser_args.get("user_data_dir") if "browser_args" in locals() else None
+        if constraints.require_patchright and not constraints.require_human_in_loop and stealth_dir:
             try:
                 cleanup_stealth_profile_dir(stealth_dir)
             except Exception as cleanup_error:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,11 @@
 
 import pytest
 import yaml
+from browser_use.browser import BrowserSession
 
 from blastai import Engine
+from blastai.config import Constraints, Settings
+from blastai.resource_factory import _build_browser_args
 
 
 @pytest.mark.asyncio
@@ -16,8 +19,42 @@ async def test_default_config():
         #   first_of_n: false
         assert engine.constraints.allow_parallelism["first_of_n"] is False
         assert engine.constraints.first_of_n_num_copies == 3
+        assert engine.settings.browser_cdp_url is None
     finally:
         await engine.stop()
+
+
+def test_external_browser_cdp_url():
+    """Accept both HTTP discovery URLs and direct WebSocket URLs."""
+    assert Settings(browser_cdp_url="https://browser.example/cdp").browser_cdp_url == "https://browser.example/cdp"
+    assert Settings(browser_cdp_url="wss://browser.example/cdp").browser_cdp_url == "wss://browser.example/cdp"
+
+
+def test_external_browser_cdp_url_reaches_browser_session_args():
+    settings = Settings(browser_cdp_url="wss://browser.example/cdp")
+    constraints = Constraints(require_patchright=True, allowed_domains=["example.com"])
+
+    browser_args = _build_browser_args("external-browser-test", constraints, settings)
+
+    assert browser_args["cdp_url"] == "wss://browser.example/cdp"
+    assert browser_args["allowed_domains"] == ["example.com"]
+    assert browser_args["user_data_dir"] is None
+    assert "executable_path" not in browser_args
+
+    browser_session = BrowserSession(**browser_args)
+    assert browser_session.cdp_url == "wss://browser.example/cdp"
+    assert browser_session.is_local is False
+
+
+@pytest.mark.parametrize("cdp_url", ["browser.example/cdp", "ftp://browser.example/cdp"])
+def test_external_browser_cdp_url_rejects_unsupported_schemes(cdp_url):
+    with pytest.raises(ValueError, match="browser_cdp_url must start"):
+        Settings(browser_cdp_url=cdp_url)
+
+
+def test_external_browser_cannot_also_launch_local_binary():
+    with pytest.raises(ValueError, match="cannot be set together"):
+        Settings(browser_cdp_url="wss://browser.example/cdp", local_browser_path="auto")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #8.

## What changed

- Add `browser_cdp_url` for HTTP, HTTPS, WS, and WSS CDP endpoints.
- Reject invalid URLs and configs that set both a local browser path and a CDP URL.
- Pass the CDP URL to `BrowserSession` while leaving the remote browser's binary and profile under the provider's control.
- Keep `allowed_domains` on external sessions.

## Checks

- `uv run pytest tests -q --ignore=tests/benchmarks` — 56 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check blastai/config.py blastai/resource_factory.py tests/test_config.py` — 3 files already formatted
- `git diff --check origin/main...HEAD` — passed
